### PR TITLE
Fix equipment getting deployed after picking up bag

### DIFF
--- a/Carry Stacker Reloaded/lua/playermanager.lua
+++ b/Carry Stacker Reloaded/lua/playermanager.lua
@@ -21,10 +21,10 @@ function PlayerManager:can_carry(carry_id)
 		return master_PlayerManager_can_carry(self, carry_id)
 	end
 
-    local check_weight = PlayerManager:BLTCS_getCurrentWeight() * BLT_CarryStacker:getWeightForType(carry_id)
-    if check_weight < 0.25 then
-        return false
-    end
+  local check_weight = PlayerManager:BLTCS_getCurrentWeight() * BLT_CarryStacker:getWeightForType(carry_id)
+  if check_weight < 0.25 then
+      return false
+  end
 
 	return true
 end
@@ -33,8 +33,8 @@ local drop_all_carry_args = nil
 
 function resetVars()
 	weight = 1
-    drop_all_carry_args = nil
-    nextUpdate = nil
+  drop_all_carry_args = nil
+  nextUpdate = nil
 end
 
 local lastUpdate, nextUpdate
@@ -59,23 +59,23 @@ function drop_and_set_carry(self, ...)
 
 	if #stack_table > 0 then
 		if stack_table[#stack_table] ~= nil then
-            local cdata = stack_table[#stack_table]
-            weight = weight / BLT_CarryStacker:getWeightForType(cdata.carry_id)
+      local cdata = stack_table[#stack_table]
+      weight = weight / BLT_CarryStacker:getWeightForType(cdata.carry_id)
 
-            master_PlayerManager_drop_carry(self, ...)
+      master_PlayerManager_drop_carry(self, ...)
 
 			table.remove(stack_table, #stack_table)
-            if #stack_table > 0 then
-                cdata = stack_table[#stack_table]
-                master_PlayerManager_set_carry(self, cdata.carry_id, cdata.multiplier or 100, cdata.dye_initiated, cdata.has_dye_pack, cdata.dye_value_multiplier)
+	    if #stack_table > 0 then
+        cdata = stack_table[#stack_table]
+        master_PlayerManager_set_carry(self, cdata.carry_id, cdata.multiplier or 100, cdata.dye_initiated, cdata.has_dye_pack, cdata.dye_value_multiplier)
 
-                nextUpdate = lastUpdate + 0.1
-            else
-                weight = 1
-                resetVars()
-            end
+        nextUpdate = lastUpdate + 0.1
+	    else
+        weight = 1
+        resetVars()
+	    end
 
-            self:refresh_stack_counter()
+	    self:refresh_stack_counter()
 		end
 	end
 end
@@ -96,14 +96,14 @@ function PlayerManager:set_carry( ... )
 	end
 
 	master_PlayerManager_set_carry(self, ...)
-	
-    local cdata = self:get_my_carry_data()
-    weight = weight * BLT_CarryStacker:getWeightForType(cdata.carry_id)
+
+  local cdata = self:get_my_carry_data()
+  weight = weight * BLT_CarryStacker:getWeightForType(cdata.carry_id)
 	table.insert(stack_table, cdata)
 
 	self:refresh_stack_counter()
 end
 
 function PlayerManager:BLTCS_getCurrentWeight()
-    return weight
+  return weight
 end

--- a/Carry Stacker Reloaded/lua/playermanager.lua
+++ b/Carry Stacker Reloaded/lua/playermanager.lua
@@ -100,6 +100,7 @@ function PlayerManager:set_carry( ... )
   local cdata = self:get_my_carry_data()
   weight = weight * BLT_CarryStacker:getWeightForType(cdata.carry_id)
 	table.insert(stack_table, cdata)
+	PlayerStandard:block_use_item()
 
 	self:refresh_stack_counter()
 end

--- a/Carry Stacker Reloaded/lua/playerstandard.lua
+++ b/Carry Stacker Reloaded/lua/playerstandard.lua
@@ -1,4 +1,6 @@
 local btn_use_item_held = false
+local block_use_item_from
+local master_PlayerStandard_check_use_item = PlayerStandard._check_use_item
 
 local master_PlayerStandard_update = PlayerStandard.update
 function PlayerStandard:update(t, dt)
@@ -11,6 +13,19 @@ function PlayerStandard:update(t, dt)
 	end
 end
 
+function PlayerStandard:_check_use_item(t, input)
+	if block_use_item_from ~= nil then
+		if TimerManager:game():time() - block_use_item_from < 0.1 then
+			return false
+		end
+	end
+	return master_PlayerStandard_check_use_item(self, t, input)
+end
+
 function PlayerStandard:use_item_held()
 	return btn_use_item_held
+end
+
+function PlayerStandard:block_use_item()
+	block_use_item_from = TimerManager:game():time()
 end


### PR DESCRIPTION
Fix #2 

For some unknown reason, `input.btn_use_item_press` returns true after picking up a bag which is what causing the equipment from getting deployed even though the button held down is `interact`.

Blocking this for 0.1 second will prevent it from happening.
